### PR TITLE
ADD: largeImageMonitor

### DIFF
--- a/rabbit-base/src/main/java/com/susion/rabbit/base/config/RabbitMonitorConfig.kt
+++ b/rabbit-base/src/main/java/com/susion/rabbit/base/config/RabbitMonitorConfig.kt
@@ -29,7 +29,9 @@ class RabbitMonitorConfig(
     var fpsMonitorPkgList: ArrayList<String> = ArrayList(),
     //anr
     var anrCheckPeriodNs: Long = TimeUnit.NANOSECONDS.convert(5, TimeUnit.SECONDS),
-    var anrStackCollectPeriodNs: Long = STANDARD_FRAME_NS
+    var anrStackCollectPeriodNs: Long = STANDARD_FRAME_NS,
+    //largeImage 单位为kb
+    var largeImageMemoryThreshold: Long = 800
 ) {
     companion object {
         var STANDARD_FRAME_NS = 16666666L

--- a/rabbit-monitor/src/main/java/com/susion/rabbit/monitor/instance/LargeImageMonitor.kt
+++ b/rabbit-monitor/src/main/java/com/susion/rabbit/monitor/instance/LargeImageMonitor.kt
@@ -1,0 +1,106 @@
+package com.susion.rabbit.monitor.instance
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import android.os.Bundle
+import android.text.TextUtils
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import com.susion.rabbit.monitor.RabbitMonitor
+import com.susion.rabbit.monitor.utils.RabbitMonitorUtils.findActivityNameByView
+import com.susion.rabbit.monitor.utils.RabbitMonitorUtils.findViewIDNameByView
+
+/**
+ * 主要思路
+ * 在Activity onStop时遍历所有子View,查找ImageView
+ * 查找内存占用超过阈值的ImageView的id并记录
+ * 这种方式比起插桩方式更为简单，缺点在于实时性不够，需要在页面关闭时才会去遍历
+ */
+internal class LargeImageMonitor : Application.ActivityLifecycleCallbacks {
+    fun init(application: Application) {
+        application.registerActivityLifecycleCallbacks(this)
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
+
+    override fun onActivityStarted(activity: Activity) {}
+
+    override fun onActivityResumed(activity: Activity) {}
+
+    override fun onActivityPaused(activity: Activity) {}
+
+    override fun onActivityStopped(activity: Activity) {
+        val fragments: List<Fragment>? = getAllFragmentsFromActivity(activity)
+        if (fragments.isNullOrEmpty()) {
+            val childViews: List<View> = getAllChildViews(activity.window.decorView)
+            checkBitmapIsTooBig(activity, childViews)
+        } else {
+            for (fragment in fragments) {
+                val childViews: List<View> = getAllChildViews(fragment.view)
+                checkBitmapIsTooBig(activity, childViews, fragment::class.java.name)
+            }
+        }
+    }
+
+    override fun onActivitySaveInstanceState(activity: Activity?, outState: Bundle?) {}
+
+    override fun onActivityDestroyed(activity: Activity?) {}
+
+    private fun getAllFragmentsFromActivity(activity: Activity): List<Fragment>? {
+        if (activity is FragmentActivity) {
+            return activity.supportFragmentManager.fragments
+        }
+        return null
+    }
+
+    private fun getAllChildViews(view: View?): List<View> {
+        val allChildren = ArrayList<View>()
+        if (view is ViewGroup) {
+            for (i in 0..view.childCount) {
+                val viewChild: View = view.getChildAt(i) ?: return allChildren
+                allChildren.add(viewChild)
+                allChildren.addAll(getAllChildViews(viewChild))
+            }
+        }
+        return allChildren
+    }
+
+    private fun checkBitmapIsTooBig(
+        context: Context,
+        views: List<View>,
+        containerName: String? = null
+    ) {
+        for (view in views) {
+            checkBitmapIsTooBig(context, view, containerName)
+        }
+    }
+
+    private fun checkBitmapIsTooBig(
+        context: Context,
+        view: View,
+        containerName: String? = null
+    ) {
+        val viewIdName = findViewIDNameByView(context, view)
+        val activityName = if (containerName.isNullOrEmpty()) findActivityNameByView(view) else containerName
+        if (view is ImageView) {
+            if (view.drawable !is BitmapDrawable) {
+                return
+            }
+            val bmDrawable: BitmapDrawable? = view.drawable as BitmapDrawable?
+            val bm: Bitmap? = bmDrawable?.bitmap
+
+            bm?.let {
+                val memorySize = it.byteCount / 1024
+                if (memorySize > RabbitMonitor.mConfig.largeImageMemoryThreshold) {
+                    //TODO 保存activityName,viewId,图片信息到数据库，供后续查询
+                }
+            }
+        }
+    }
+}

--- a/rabbit-monitor/src/main/java/com/susion/rabbit/monitor/utils/RabbitMonitorUtils.kt
+++ b/rabbit-monitor/src/main/java/com/susion/rabbit/monitor/utils/RabbitMonitorUtils.kt
@@ -1,5 +1,7 @@
 package com.susion.rabbit.monitor.utils
 
+import android.content.Context
+import android.view.View
 import com.susion.rabbit.base.RabbitLog
 import com.susion.rabbit.base.TAG_MONITOR
 import com.susion.rabbit.base.entities.RabbitAnrInfo
@@ -7,6 +9,7 @@ import com.susion.rabbit.monitor.RabbitMonitor
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
+import java.lang.Exception
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.regex.Matcher
@@ -105,5 +108,27 @@ object RabbitMonitorUtils {
         return anrSB.toString()
     }
 
+    /**
+     * 根据view id反查view id name
+     */
+    internal fun findViewIDNameByView(context: Context, view: View): String? {
+        if (view.id == View.NO_ID) {
+            return null
+        }
+        var viewName: String? = null
+        try {
+            viewName = context.resources.getResourceEntryName(view.id)
+        } catch (ex: Exception) {
+            ex.printStackTrace()
+        }
+        return viewName
+    }
+
+    /**
+     * 根据view获取activity name
+     */
+    internal fun findActivityNameByView(view: View): String {
+        return view.context::class.java.name
+    }
 
 }


### PR DESCRIPTION
 主要思路
  在Activity onStop时遍历所有子View,查找ImageView
 查找内存占用超过阈值的ImageView的id并记录
 这种方式比起插桩方式更为简单，缺点在于实时性不够，需要在页面关闭时才会去遍历
 
本次提交主要包括监控相关，示例及入口相关代码后续添加